### PR TITLE
Only add domain name to domains, not sensor name

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -391,7 +391,7 @@ def setup(hass, config):
         fw_type = service.data.get(ATTR_FW_TYPE)
         fw_version = service.data.get(ATTR_FW_VERSION)
         fw_path = service.data.get(ATTR_FW_PATH)
-        domains = [split_entity_id(entity_id) for entity_id in entity_ids]
+        domains = [split_entity_id(entity_id)[0] for entity_id in entity_ids]
         all_devices = [
             device for domain in domains
             for device in get_mysensors_devices(hass, domain).values()]


### PR DESCRIPTION
Fixes the issue [mentioned in the forum](https://community.home-assistant.io/t/mysensors-ota-firmware-updates/27779/5). On my setup, this change has successfully uploaded a new firmware to a sensor. I have not yet done testing with more complicated situations like updating multiple sensors at once.

The results of `split_entity_id(entity_id)` were being added to a list, resulting in a list of lists. This does not seem to be the intention. Actually, I think we only want to add the domain to the list. That's the 0-th element of the list.

I'm not a contributor for HA, and not sufficiently aware of the guidelines. Hope you'll be able to get the OTA working with this change. Thanks for the great component!
